### PR TITLE
Return mexData pointer on r4

### DIFF
--- a/asm/m-ex/Standalone Functions/LoadRELDAT.asm
+++ b/asm/m-ex/Standalone Functions/LoadRELDAT.asm
@@ -49,6 +49,7 @@ mexPatch_Skip:
   branchl r12,0x80328f50
 
   mr r3,REG_Header
+  mr r4,REG_mexData
   restore
   blr
 


### PR DESCRIPTION
This allows using LoadRELDat to create custom hooks in the following way:

```asm
backupall
  .set REG_FX_ARRAY, 31
  .set REG_MEX_DATA, 30

  # Execute LoadRELDAT
  bl  FileName
  mflr  r3 # Hooks.dat
  addi  r4,sp,0x80 # FXStructPointer
  bl  SymbolName # slpFunction
  mflr  r5
  branchl r12, 0x803d709c # Standalone function LoadRELDAT
  mr REG_MEX_DATA, r4

  # Find offset to OnCSSLoad:
  lwz REG_FX_ARRAY, 0x80(sp)
  lwz r3, 0xC(REG_MEX_DATA) # FX Table
  lwz r3, 0x5*4(r3) # Offset to OnCSSLoad
  add r3, r3, REG_FX_ARRAY # offset from fx array to OnCSSLoad
  mtctr r3
  bctrl # execute OnCSSLoad

restoreall
b EXIT
```

If there's any other way to achieve this, I'm open to suggestions <3